### PR TITLE
lazy-load plugin and support Vim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Like [jqplay.org](https://jqplay.org) or Neovims builtin Treesitter playground
 ([`:InspectTree`](https://neovim.io/doc/user/treesitter.html#%3AInspectTree)).
 
-> [!NOTE]
+> [!WARNING]
 > Using the `setup()` function is deprecated. To upgrade, set
 > `vim.g.jq_playground` to your config. Read more about this in the
 > [Configuration](#configuration) section.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,32 @@
 # jq-playground.nvim
 
-> Interact with jq in Neovim, using interactive buffers
+> Interact with jq in Neovim using interactive buffers
 
 ![Example screenshot](example/screenshot.png)
 
 Like [jqplay.org](https://jqplay.org) or Neovims builtin Treesitter playground
 ([`:InspectTree`](https://neovim.io/doc/user/treesitter.html#%3AInspectTree)).
 
+> [!NOTE] Using the `setup()` function is deprecated. To upgrade, set
+> `vim.g.jq_playground` to your config. Read more about this in the
+> [Configuration](#configuration) section.
+
 ## Installation
 
-### Lazy.nvim
+The GitHub repository is at `"yochem/jq-playground.nvim"`. Use that in your
+package manager. No other configuration needed.
 
-Using the default configuration with
-[lazy.nvim](https://github.com/folke/lazy.nvim) as package manager:
-
-```lua
-{
-  "yochem/jq-playground.nvim"
-}
-```
-
-This will lazy-load the plugin on `:JqPlayground`, as defined in the
-[packspec](https://github.com/neovim/packspec) (which Lazy supports) in this
-repo: [pkg.json](./pkg.json).
-
-### Other Package Managers
-
-If you use another package manager than lazy.nvim, make sure to run the setup
-function to register the `:JqPlayground` command:
-
-```lua
-require("jq-playground").setup()
-```
+The plugin is lazy-loaded on `:JqPlayground` and does not require any
+lazy-loading configuration by the user.
 
 ## Configuration
 
-These are the options, along with their defaults. Set `opts` in lazy to this
-table, or pass the table to the `setup()` function.
+All possible configuration and the default values can be found in
+[`jq-playground/config.lua`](./lua/jq-playground/config.lua), but this is it:
 
 ```lua
-{
+-- notice how the configuration is handled via vim.g
+vim.g.jq_playground = {
   output_window = {
     split_direction = "right",
     width = nil,
@@ -50,58 +37,63 @@ table, or pass the table to the `setup()` function.
     width = nil,
     height = 0.3,
   },
-  query_keymaps = {
-    { "n", "<CR>" },
-  },
-})
+  disable_default_keymap = false,
+}
 ```
 
 - `split_direction`: can be `"left"`, `"right"`, `"above"` or `"below"`. The
   split direction of the output window is relative to the input window, and the
-  query window is relative to the output window.
+  query window is relative to the output window (they open after each other).
 - `width` and `height`:
   - `nil`: use the default (half of current width/height)
   - `0-1`: percentage of current width/height
   - `>1`: absolute width/height in number of characters or lines
-- `query_keymaps`: keymaps to refresh the output buffer. Should be given as a
-  table of first two arguments for `vim.keymap.set`. Changing this setting will
-  override the default keymap (`<CR>` in normal mode).
+- `disable_default_keymap`: disables default `<CR>` map in the query window
 
-## `:JqPlayground`
+Their are two commands that can be remapped: the user-command `:JqPlayground`
+that starts the playground, and `<Plug>(JqPlaygroundRunQuery)`, that runs the
+current query when pressed with the cursor in the query window. Remap them the
+following way:
+
+```lua
+vim.keymap.set("n", "<leader>jq", vim.cmd.JqPlayground)
+
+vim.keymap.set("n", "R", "<Plug>(JqPlaygroundRunQuery)")
+```
+
+## Usage
 
 Navigate to a JSON file, and execute the command `:JqPlayground`. Two scratch
 buffers will be opened: a buffer for the JQ-filter and one for displaying the
-results. Simply press `<CR>` (enter), or your keymap from setup, in the filter
+results. Simply press `<CR>` (enter), or your keymap from setup, in the query
 window to refresh the results buffer.
 
 You can also provide a filename to the `:JqPlayground` command. This is useful
 if the JSON file is very large and you don't want to open it in Neovim
 directly:
 
-```
+```vim
 :JqPlayground sample.json
 ```
 
 ## Tips
 
+Some random tips of useful builtin Nvim functionality that could be useful.
+
 If you have a saved filter that you want to load into the filter window, then
 run:
 
-```
+```vim
 :r /path/to/some/query.jq
 ```
 
 If you want to save the current query or output json, navigate to that buffer
 and run:
 
-```
-:w /path/to/save/{query.jq,output.json}
-```
-
-If you want to use a keymap instead of the `:JqPlayground` command, use this:
-
-```lua
-vim.keymap.set('n', '<leader>jq', vim.cmd.JqPlayground)
+```vim
+:w path/to/save/query.jq
+" or:
+:w path/to/save/output.json
 ```
 
 Start the JQ editor from the command line without loading the input file:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 Like [jqplay.org](https://jqplay.org) or Neovims builtin Treesitter playground
 ([`:InspectTree`](https://neovim.io/doc/user/treesitter.html#%3AInspectTree)).
 
-> [!NOTE] Using the `setup()` function is deprecated. To upgrade, set
+> [!NOTE]
+> Using the `setup()` function is deprecated. To upgrade, set
 > `vim.g.jq_playground` to your config. Read more about this in the
 > [Configuration](#configuration) section.
 

--- a/lua/jq-playground/config.lua
+++ b/lua/jq-playground/config.lua
@@ -1,0 +1,17 @@
+return {
+  output_window = {
+    split_direction = "right",
+    width = nil,
+    height = nil,
+  },
+  query_window = {
+    split_direction = "below",
+    width = nil,
+    height = 0.3,
+  },
+  disable_default_keymap = false,
+  -- TODO: deprecate
+  query_keymaps = {
+    { "n", "<CR>" },
+  },
+}

--- a/lua/jq-playground/health.lua
+++ b/lua/jq-playground/health.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+M.check = function()
+  vim.health.start("Configuration")
+  if vim.g.jq_playground == nil then
+    vim.health.info("no user configuration found: vim.g.jq_playground does not exist")
+  else
+    -- TODO: validate config
+    vim.health.ok("user configuration found: vim.g.jq_playground exists")
+  end
+  -- TODO: check if lazy loaded
+end
+
+return M

--- a/lua/jq-playground/init.lua
+++ b/lua/jq-playground/init.lua
@@ -1,154 +1,35 @@
 local M = {}
 
+-- TODO: fix code duplication
 local function show_error(msg)
   vim.notify("jq-playground: " .. msg, vim.log.levels.ERROR, {})
 end
 
-local function user_preferred_indent(json_bufnr)
-  local prefer_tabs = not vim.bo[json_bufnr].expandtab
-  if prefer_tabs then
-    return { "--tab" }
-  else
-    local indent_width = vim.bo[json_bufnr].softtabstop
-    return { "--indent", indent_width }
-  end
-end
-
--- TODO: refactor
-local function run_query(input, query_bufnr, output_bufnr)
-  local filter_lines = vim.api.nvim_buf_get_lines(query_bufnr, 0, -1, false)
-  local filter = table.concat(filter_lines, "\n")
-  local cmd = { "jq", filter }
-  vim.list_extend(cmd, user_preferred_indent(output_bufnr))
-  local stdin = nil
-
-  if type(input) == "number" and vim.api.nvim_buf_is_valid(input) then
-    local modified = vim.bo[input].modified
-    local fname = vim.api.nvim_buf_get_name(input)
-
-    if (not modified) and fname ~= "" then
-      -- the following should be faster as it lets jq read the file contents
-      table.insert(cmd, fname)
-    else
-      stdin = vim.api.nvim_buf_get_lines(input, 0, -1, false)
-    end
-  elseif type(input) == "string" and vim.fn.filereadable(input) == 1 then
-    table.insert(cmd, input)
-  else
-    show_error("invalid input: " .. input)
-  end
-  local ok, process = pcall(vim.system, cmd, { stdin = stdin })
-
-  if not ok then
-    show_error("jq is not installed or not on your $PATH")
-    return
-  end
-
-  local result = process:wait()
-  local output = result.code == 0 and result.stdout or result.stderr
-
-  local lines = vim.split(output, "\n", { plain = true })
-  vim.api.nvim_buf_set_lines(output_bufnr, 0, -1, false, lines)
-end
-
-local function resolve_winsize(num, max)
-  if num == nil or (1 <= num and num <= max) then
-    return num
-  elseif 0 < num and num < 1 then
-    return math.floor(num * max)
-  else
-    show_error(string.format("incorrect winsize, received %s of max %s", num, max))
-  end
-end
-
-local function create_split_scratch_buf(bufopts, winopts)
-  local bufnr = vim.api.nvim_create_buf(false, true)
-  vim.bo[bufnr].filetype = bufopts.filetype
-  vim.api.nvim_buf_set_name(bufnr, bufopts.name)
-
-  local height = resolve_winsize(winopts.height, vim.api.nvim_win_get_height(0))
-  local width = resolve_winsize(winopts.width, vim.api.nvim_win_get_width(0))
-
-  local winid = vim.api.nvim_open_win(bufnr, true, {
-    split = winopts.split_direction,
-    width = width,
-    height = height,
-  })
-
-  return bufnr, winid
-end
-
-function M.init_playground(opts)
-  local input_json_bufnr = vim.api.nvim_get_current_buf()
-
-  local output_json_bufnr, _ = create_split_scratch_buf({
-    name = "jq output",
-    filetype = "json",
-  }, opts.output_window)
-
-  local query_bufnr, winid = create_split_scratch_buf({
-    name = "jq query editor",
-    filetype = "jq",
-  }, opts.query_window)
-
-  vim.api.nvim_buf_set_lines(query_bufnr, 0, -1, false, {
-    -- TODO: change text
-    "# JQ filter: press set keymap (default <CR> in normal mode) to execute.",
-    "",
-    "",
-  })
-  vim.api.nvim_win_set_cursor(winid, { 3, 0 })
-  vim.cmd.startinsert()
-
-  local run_jq_query = function()
-    run_query(opts.filename or input_json_bufnr, query_bufnr, output_json_bufnr)
-  end
-
-  -- TODO: deprecate
-  for _, mapping in ipairs(opts.query_keymaps) do
-    vim.keymap.set(mapping[1], mapping[2], run_jq_query, {
-      buffer = query_bufnr,
-      silent = true,
-      desc = "Run jq query",
-    })
-  end
-
-  vim.keymap.set({ "n", "i" }, "<Plug>(JqPlaygroundRunQuery)", run_jq_query, {
-    buffer = query_bufnr,
-    silent = true,
-    desc = "JqPlaygroundRunQuery",
-  })
-
-  -- To have a sensible default. Does not require user to define one
-  if not opts.disable_default_keymap then
-    vim.keymap.set({ "n" }, "<CR>", "<Plug>(JqPlaygroundRunQuery)", {
-      desc = "Default for JqPlaygroundRunQuery",
-    })
-  end
-end
-
--- TODO: deprecate
 function M.setup(opts)
   local defaults = require("jq-playground.config")
 
-  local options = vim.tbl_deep_extend("force", defaults, opts or {})
+  local global_config = vim.g.jq_playground or {}
+  local setup_config = opts or {}
+
+  if not vim.tbl_isempty(global_config) and not vim.tbl_isempty(setup_config) then
+    show_error("Two configs detected: vim.g.jq_playground and setup(). Use only one.")
+  end
+
+  -- vim.g.jq_playground, then opts, then defaults
+  vim.g.jq_playground = vim.tbl_deep_extend(
+    "force",
+    defaults,
+    setup_config,
+    global_config
+  )
 
   vim.api.nvim_create_user_command("JqPlayground", function(params)
-    options["filename"] = params.fargs[1]
-    M.init_playground(options)
+    require("jq-playground.playground").init_playground(params.fargs[1])
   end, {
     desc = "Start jq query editor and live preview",
     nargs = "?",
     complete = "file",
   })
-
-  vim.deprecate(
-    "require('jq-playground').setup()",
-    "vim.g.jq_playground = {}",
-    "0.2",
-    "jq-playground",
-    false
-  )
 end
 
 return M

--- a/lua/jq-playground/playground.lua
+++ b/lua/jq-playground/playground.lua
@@ -106,6 +106,15 @@ function M.init_playground(filename)
   end
 
   -- TODO: deprecate
+  if config.query_keymaps ~= nil then
+    vim.deprecate(
+      "config.query_keymaps",
+      "vim.keymap.set with <Plug>(JqPlaygroundRunQuery)",
+      "0.2",
+      "jq-playground",
+      false
+    )
+  end
   for _, mapping in ipairs(config.query_keymaps) do
     vim.keymap.set(mapping[1], mapping[2], run_jq_query, {
       buffer = query_bufnr,

--- a/lua/jq-playground/playground.lua
+++ b/lua/jq-playground/playground.lua
@@ -1,0 +1,131 @@
+local M = {}
+
+local function show_error(msg)
+  vim.notify("jq-playground: " .. msg, vim.log.levels.ERROR, {})
+end
+
+local function user_preferred_indent(json_bufnr)
+  local prefer_tabs = not vim.bo[json_bufnr].expandtab
+  if prefer_tabs then
+    return { "--tab" }
+  else
+    local indent_width = vim.bo[json_bufnr].softtabstop
+    return { "--indent", indent_width }
+  end
+end
+
+-- TODO: refactor
+local function run_query(input, query_bufnr, output_bufnr)
+  local filter_lines = vim.api.nvim_buf_get_lines(query_bufnr, 0, -1, false)
+  local filter = table.concat(filter_lines, "\n")
+  local cmd = { "jq", filter }
+  vim.list_extend(cmd, user_preferred_indent(output_bufnr))
+  local stdin = nil
+
+  if type(input) == "number" and vim.api.nvim_buf_is_valid(input) then
+    local modified = vim.bo[input].modified
+    local fname = vim.api.nvim_buf_get_name(input)
+
+    if (not modified) and fname ~= "" then
+      -- the following should be faster as it lets jq read the file contents
+      table.insert(cmd, fname)
+    else
+      stdin = vim.api.nvim_buf_get_lines(input, 0, -1, false)
+    end
+  elseif type(input) == "string" and vim.fn.filereadable(input) == 1 then
+    table.insert(cmd, input)
+  else
+    show_error("invalid input: " .. input)
+  end
+  local ok, process = pcall(vim.system, cmd, { stdin = stdin })
+
+  if not ok then
+    show_error("jq is not installed or not on your $PATH")
+    return
+  end
+
+  local result = process:wait()
+  local output = result.code == 0 and result.stdout or result.stderr
+
+  local lines = vim.split(output, "\n", { plain = true })
+  vim.api.nvim_buf_set_lines(output_bufnr, 0, -1, false, lines)
+end
+
+local function resolve_winsize(num, max)
+  if num == nil or (1 <= num and num <= max) then
+    return num
+  elseif 0 < num and num < 1 then
+    return math.floor(num * max)
+  else
+    show_error(string.format("incorrect winsize, received %s of max %s", num, max))
+  end
+end
+
+local function create_split_scratch_buf(bufopts, winopts)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[bufnr].filetype = bufopts.filetype
+  vim.api.nvim_buf_set_name(bufnr, bufopts.name)
+
+  local height = resolve_winsize(winopts.height, vim.api.nvim_win_get_height(0))
+  local width = resolve_winsize(winopts.width, vim.api.nvim_win_get_width(0))
+
+  local winid = vim.api.nvim_open_win(bufnr, true, {
+    split = winopts.split_direction,
+    width = width,
+    height = height,
+  })
+
+  return bufnr, winid
+end
+
+function M.init_playground(filename)
+  local config = vim.g.jq_playground
+  local input_json_bufnr = vim.api.nvim_get_current_buf()
+
+  local output_json_bufnr, _ = create_split_scratch_buf({
+    name = "jq output",
+    filetype = "json",
+  }, config.output_window)
+
+  local query_bufnr, winid = create_split_scratch_buf({
+    name = "jq query editor",
+    filetype = "jq",
+  }, config.query_window)
+
+  vim.api.nvim_buf_set_lines(query_bufnr, 0, -1, false, {
+    -- TODO: change text
+    "# JQ filter: press set keymap (default <CR> in normal mode) to execute.",
+    "",
+    "",
+  })
+  vim.api.nvim_win_set_cursor(winid, { 3, 0 })
+  vim.cmd.startinsert()
+
+  local run_jq_query = function()
+    run_query(filename or input_json_bufnr, query_bufnr, output_json_bufnr)
+  end
+
+  -- TODO: deprecate
+  for _, mapping in ipairs(config.query_keymaps) do
+    vim.keymap.set(mapping[1], mapping[2], run_jq_query, {
+      buffer = query_bufnr,
+      silent = true,
+      desc = "Run jq query",
+    })
+  end
+
+  vim.keymap.set({ "n", "i" }, "<Plug>(JqPlaygroundRunQuery)", run_jq_query, {
+    buffer = query_bufnr,
+    silent = true,
+    desc = "JqPlaygroundRunQuery",
+  })
+
+  -- To have a sensible default. Does not require user to define one
+  if not config.disable_default_keymap then
+    vim.keymap.set({ "n" }, "<CR>", "<Plug>(JqPlaygroundRunQuery)", {
+      desc = "Default for JqPlaygroundRunQuery",
+    })
+  end
+end
+
+return M

--- a/pkg.json
+++ b/pkg.json
@@ -8,9 +8,5 @@
     "type": "git",
     "url": "https://github.com/yochem/jq-playground.nvim"
   },
-  "dependencies": {},
-  "lazy": {
-    "opts": {},
-    "cmd": "JqPlayground"
-  }
+  "dependencies": {}
 }

--- a/plugin/jq-playground.lua
+++ b/plugin/jq-playground.lua
@@ -1,0 +1,15 @@
+if not vim.g.loaded_jq_playground then
+  local defaults = require("jq-playground.config")
+
+  local options = vim.tbl_deep_extend("force", defaults, vim.g.jq_playground or {})
+
+  vim.api.nvim_create_user_command("JqPlayground", function(params)
+    options["filename"] = params.fargs[1]
+    require("jq-playground").init_playground(options)
+  end, {
+    desc = "Start jq query editor and live preview",
+    nargs = "?",
+    complete = "file",
+  })
+end
+vim.g.loaded_jq_playground = true

--- a/plugin/jq-playground.lua
+++ b/plugin/jq-playground.lua
@@ -1,15 +1,4 @@
 if not vim.g.loaded_jq_playground then
-  local defaults = require("jq-playground.config")
-
-  local options = vim.tbl_deep_extend("force", defaults, vim.g.jq_playground or {})
-
-  vim.api.nvim_create_user_command("JqPlayground", function(params)
-    options["filename"] = params.fargs[1]
-    require("jq-playground").init_playground(options)
-  end, {
-    desc = "Start jq query editor and live preview",
-    nargs = "?",
-    complete = "file",
-  })
+  require("jq-playground").setup()
 end
 vim.g.loaded_jq_playground = true


### PR DESCRIPTION
This PR follows recommendations from these blogposts:

- https://mrcjkb.dev/posts/2023-08-22-setup.html
- https://zignar.net/2022/11/06/structuring-neovim-lua-plugins/
- https://github.com/nvim-neorocks/nvim-best-practices

Improvements:
- Using `plugin/` autoloads and only sets the user command `:JqPlayground` (rest is lazy)
- Fixed lazy.nvim preventing `health.lua` to be loaded
- `vim.g.jq_playground` for config, doesn't break nvim if plugin is missing
- `vim.keymap.set` with `<Plug>(JqPlaygroundRunQuery)`, same as above and native nvim way (can take over the buffer-locality)

Backwards compatibility:
- `setup()` still works.

Breaks:
- Automatic lazy loading by lazy.nvim (but not necessary anymore)
- `config.query_keymaps` will be deprecated