### PR TITLE
fix: crash when re-opening playground

### DIFF
--- a/lua/jq-playground/playground.lua
+++ b/lua/jq-playground/playground.lua
@@ -69,9 +69,12 @@ local function resolve_winsize(num, max)
 end
 
 local function create_split_scratch_buf(bufopts, winopts)
-  local bufnr = vim.api.nvim_create_buf(false, true)
-  vim.bo[bufnr].filetype = bufopts.filetype
-  vim.api.nvim_buf_set_name(bufnr, bufopts.name)
+  local bufnr = vim.fn.bufnr(bufopts.name)
+  if bufnr == -1 then
+    bufnr = vim.api.nvim_create_buf(false, true)
+    vim.bo[bufnr].filetype = bufopts.filetype
+    vim.api.nvim_buf_set_name(bufnr, bufopts.name)
+  end
 
   local height = resolve_winsize(winopts.height, vim.api.nvim_win_get_height(0))
   local width = resolve_winsize(winopts.width, vim.api.nvim_win_get_width(0))
@@ -99,6 +102,7 @@ function M.init_playground(filename)
     filetype = "jq",
   }, config.query_window)
 
+  vim.api.nvim_buf_set_lines(output_json_bufnr, 0, -1, false, {})
   vim.api.nvim_buf_set_lines(query_bufnr, 0, -1, false, {
     -- TODO: change text
     "# JQ filter: press set keymap (default <CR> in normal mode) to execute.",


### PR DESCRIPTION
Fixes a bug where if I close the buffers created by `:JqPlayground`, and re-run the command again, the plugin crashes:

```
Error executing Lua callback: ...lazy/jq-playground.nvim/lua/jq-playground/playground.lua:74: Vim:E95: Buffer with this name already exists
stack traceback:                                                                                                                                         
    [C]: in function 'nvim_buf_set_name'                                                                                                             
    ...lazy/jq-playground.nvim/lua/jq-playground/playground.lua:74: in function 'create_split_scratch_buf'
    ...lazy/jq-playground.nvim/lua/jq-playground/playground.lua:92: in function 'init_playground'                                                    
    ...-data/lazy/jq-playground.nvim/lua/jq-playground/init.lua:9: in function <...-data/lazy/jq-playground.nvim/lua/jq-playground/init.lua:8>
```

Before:

https://github.com/user-attachments/assets/edbc450a-170d-45a1-9714-7d421cb57d88

After:

https://github.com/user-attachments/assets/fe31e0df-850f-4968-9d7f-5447d49cdaee