### PR TITLE
added buffer local variable jqplayground_inputbuf to find the filename of json

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ directly:
 :JqPlayground sample.json
 ```
 
+## Buffer Variables
+
+The query buffer (jq/yq editor) has access to the following buffer-local variables:
+
+- `vim.b.jqplayground_inputbuf`: Contains the buffer number of the input buffer
+(JSON/YAML file). This variable is set before filetype plugins run, making it
+available in filetype-specific configurations. This can be used in custom
+keymaps to access the original filename or content.
+
+Example usage:
+```lua
+-- In the query buffer, get the input filename
+local input_filename = vim.api.nvim_buf_get_name(vim.b.jqplayground_inputbuf)
+
+-- Build a command string for copying to clipboard
+local query_content = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+local cmd = string.format("%s '%s' '%s'", vim.o.filetype, query_content, input_filename)
+vim.fn.setreg("+", cmd)
+```
+
 ## Tips
 
 Some random tips that you may find useful while using this plugin.

--- a/lua/jq-playground/playground.lua
+++ b/lua/jq-playground/playground.lua
@@ -84,7 +84,7 @@ local function create_split_buf(opts, before_filetype_callback)
     buf = vim.api.nvim_create_buf(true, opts.scratch)
 
     -- Run callback before setting filetype
-    if before_filetype_callback then
+    if before_filetype_callback and vim.is_callable(before_filetype_callback) then
       before_filetype_callback(buf)
     end
 
@@ -139,7 +139,7 @@ function M.init_playground(filename)
 
   -- And then query buffer
   local query_buf, _ = create_split_buf(cfg.query_window, function(new_buf)
-    vim.api.nvim_buf_set_var(new_buf, "parent_bufnr", curbuf)
+    vim.b[new_buf].jqplayground_inputbuf = curbuf
   end)
   virt_text_hint(query_buf, "Run your query with <CR>.")
 

--- a/lua/jq-playground/playground.lua
+++ b/lua/jq-playground/playground.lua
@@ -55,7 +55,7 @@ local function run_query(cmd, input, query_buf, output_buf)
   end
 
   local on_exit = function(result)
-    vim.schedule(function ()
+    vim.schedule(function()
       local out = result.code == 0 and result.stdout or result.stderr
       local lines = vim.split(out, "\n", { plain = true })
       vim.api.nvim_buf_set_lines(output_buf, 0, -1, false, lines)
@@ -83,7 +83,9 @@ local function create_split_buf(opts, before_filetype_callback)
   if buf == -1 then
     buf = vim.api.nvim_create_buf(true, opts.scratch)
 
-    -- Run callback before setting filetype
+    -- Execute callback before setting filetype to ensure buffer variables are
+    -- available to ftplugin scripts and FileType autocmds that get triggered
+    -- (e.g., for building keymaps that reference the input buffer)
     if before_filetype_callback and vim.is_callable(before_filetype_callback) then
       before_filetype_callback(buf)
     end


### PR DESCRIPTION
I must be able to refer to the parent buffer from the `query_buf`. Previously, `curbuf` was a local variable, and captured in the "run the query" labmda, and thus never exposed to a user scripting against this. By exposing `curbuf` to `query_buf`, we gain power.

I figured calling it `curbuf` would be a misnomer, so I used `parent_bufnr`

Here is an example of the use, [from my dotfiles](https://github.com/AriSweedler/dotfiles/blob/84ddc6b928748c7295e6044b305baf8f858f9ead/.config/nvim/lua/plugins/jq-playground.lua#L26-L37). To build the `cmd`, I need to have the filename.

```
	bufmap("Y", function()
		-- Grab full buffer
		local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
		local content = table.concat(lines, "\n")
		local escaped = xq_escape(content)

		-- Build command and copy to clipboard
		local cmd = vim.o.filetype .. " '" .. escaped .. "' " .. vim.api.nvim_buf_get_name(vim.b.parent_bufnr)
		vim.fn.setreg("+", cmd)

		vim.notify("Copied " .. vim.o.filetype .. " command: " .. cmd, vim.log.levels.INFO)
	end, "Copy buffer into " .. vim.o.filetype .. " command")
```

It is useful to have this cmd becauyse then I can immediately paste into a terminal and get the same results, but persist into my terminal history. I commonly use this workflow to pipe to another unix function or to add to my notes.