### PR TITLE
feat(http): add JqPlaygroundHttp with save/load, env vars, and JSON formatting

### DIFF
--- a/lua/jq-playground/init.lua
+++ b/lua/jq-playground/init.lua
@@ -14,4 +14,12 @@ function M.setup(opts)
   })
 end
 
+function M.run_query()
+  require("jq-playground.playground").run_query()
+end
+
+function M.get_bufs()
+  return require("jq-playground.playground").get_bufs()
+end
+
 return M

--- a/lua/jq-playground/playground.lua
+++ b/lua/jq-playground/playground.lua
@@ -2,6 +2,8 @@ local M = {}
 local ns = vim.api.nvim_create_namespace("jq-playground")
 local augroup = vim.api.nvim_create_augroup("jq-playground", {})
 
+local active = nil
+
 local function show_error(msg)
   vim.notify("jq-playground: " .. msg, vim.log.levels.ERROR, {})
 end
@@ -144,6 +146,8 @@ function M.init_playground(filename)
   end)
   virt_text_hint(query_buf, "Run your query with <CR>.")
 
+  active = { cmd = cfg.cmd, input = filename or curbuf, query_buf = query_buf, output_buf = output_buf }
+
   vim.keymap.set({ "n", "i" }, "<Plug>(JqPlaygroundRunQuery)", function()
     run_query(cfg.cmd, filename or curbuf, query_buf, output_buf)
   end, {
@@ -158,6 +162,18 @@ function M.init_playground(filename)
       desc = "Default for JqPlaygroundRunQuery",
     })
   end
+end
+
+function M.run_query()
+  if not active then
+    show_error("no active playground")
+    return
+  end
+  run_query(active.cmd, active.input, active.query_buf, active.output_buf)
+end
+
+function M.get_bufs()
+  return active
 end
 
 return M


### PR DESCRIPTION
- New JqPlaygroundHttp command with save/load subcommands and Tab autocomplete
- Persist HTTP requests to configurable path_to_save_http directory; last saved file auto-loads on next open
- Source .env file before curl execution (configurable env_file option, overrides system env)
- Auto-format compact JSON in -d/--data/--data-raw bodies to multiline on query run
- Fix httpJson syntax region to support --data and --data-raw flags
- Add httpJsonKey highlight group to differentiate JSON keys from string values
- Close original window when opening playground modes